### PR TITLE
increase max length of pdf vars for long path of singularity in cvmfs

### DIFF
--- a/linit.F
+++ b/linit.F
@@ -14,7 +14,7 @@ C...Numerical integration to obtain total cross-section.
      &Q2MIN,Q2MAX,W2MIN,W2MAX,ILEP,INU,IG,IZ
       REAL PSAVE,XMIN,XMAX,YMIN,YMAX,Q2MIN,Q2MAX,W2MIN,W2MAX
       INTEGER KSAVE,ILEP,INU,IG,IZ
-      character*100  clasdispdf
+      character*500  clasdispdf
       SAVE /LINTRL/
 
 *

--- a/parton.F
+++ b/parton.F
@@ -3795,7 +3795,7 @@ C************************************************************************
       CHARACTER*80 LINE
       COMMON / INTINIP / IINIP
 c
-      character*100  pdffile,clasdispdf
+      character*500  pdffile,clasdispdf
 c
       SAVE XUVF, XDVF, XDEF, XUDF, XSF, XGF, NA, ARRF
 
@@ -4103,7 +4103,7 @@ c
      1          XSF(NX,NQ), XGF(NX,NQ), XG1P(NX,NQ), XG1N(NX,NQ),
      2          PARTON (NPART,NQ,NX-1), QS(NQ), XB(NX), XT(NARG), 
      3          NA(NARG), ARRF(NX+NQ) 
-      character*100  pdffile,clasdispdf
+      character*500  pdffile,clasdispdf
 c
       COMMON / INTINI / IINI
       SAVE XUF, XDF, XUBF, XDBF, XSF, XGF, XG1P, XG1N, NA, ARRF

--- a/pepsi423.F
+++ b/pepsi423.F
@@ -467,7 +467,7 @@ C...Numerical integration to obtain total cross-section.
       REAL ULMASS,ULANGL,UMIN,UMAX,S
       INTEGER LQCD,LTM,IPMAX,IP,IW,IX
       REAL TI1,TI2
-      character*100  clasdispdf
+      character*500  clasdispdf
 c
       INTEGER LSTW(40)
       REAL PARLW(30)
@@ -10275,7 +10275,7 @@ C...  Numerical integration to obtain total cross-section.
       REAL ULMASS,ULANGL,UMIN,UMAX
       INTEGER LQCD,LTM,IPMAX,IP,IW,IX
       REAL TI1,TI2
-      character*100  clasdispdf
+      character*500  clasdispdf
 c
       INTEGER LSTW(40)
       REAL PARLW(30)


### PR DESCRIPTION
Due to recent mount of singularity image in cvmfs, not in scosg16, the path length of pdf variables have become too long for char*100. This PR increases the size of char* variables related to pdf grid, i.e., ```clasdispdf``` and ```pdffile```.